### PR TITLE
server: SWA-aware fallback for --spec-type dflash probe + unblock 4 compile-time regressions from the upstream/master merge

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -353,6 +353,16 @@ struct common_params_speculative {
 
     common_params_speculative_ngram_cache ngram_cache;
 
+    // Cross-vocab token replacement pairs for spec-decode: when the
+    // target and draft models have different tokenizers, replace
+    // occurrences of `first` (target-tokenizer string) with `second`
+    // (draft-tokenizer string) in the prompt fed to the draft model.
+    // Wired by the `--spec-replace TARGET DRAFT` CLI flag and consumed
+    // by `common_speculative_apply_replacements()`. Required by the
+    // upstream/master speculative-decode rewrite that landed in
+    // 79079c25e but not added to this struct as part of that merge.
+    std::vector<std::pair<std::string, std::string>> replacements;
+
     bool has_dft() const {
         return !draft.mparams.path.empty() || !draft.mparams.hf_repo.empty();
     }

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -889,7 +889,11 @@ common_speculative * common_speculative_init(common_params_speculative & params,
         bool has_ngram_mod     = (enabled_configs & (1u << COMMON_SPECULATIVE_TYPE_NGRAM_MOD));
 
         // when adding a new type - update here the logic above
-        static_assert(COMMON_SPECULATIVE_TYPE_COUNT == 8);
+        // Bump: DFLASH was added to the enum (between NGRAM_CACHE and
+        // COUNT) so COUNT is now 9. DFLASH dispatches through has_draft
+        // (see enum comment: "behaves like DRAFT when -md is provided")
+        // so it doesn't need a separate has_* bool here.
+        static_assert(COMMON_SPECULATIVE_TYPE_COUNT == 9);
 
         // this list here defines the priority of the speculators
         // the one with highest priority are listed first

--- a/ggml/src/ggml-quants.c
+++ b/ggml/src/ggml-quants.c
@@ -235,41 +235,6 @@ void quantize_row_q1_0_g128_ref(const float * GGML_RESTRICT x, block_q1_0_g128 *
 }
 
 // reference implementation for deterministic creation of model files
-void quantize_row_q1_0_ref(const float * GGML_RESTRICT x, block_q1_0 * GGML_RESTRICT y, int64_t k) {
-    static const int qk = QK1_0;
-
-    assert(k % qk == 0);
-
-    const int nb = k / qk;
-
-    for (int i = 0; i < nb; i++) {
-        float sum_abs = 0.0f;
-        for (int j = 0; j < qk; j++) {
-            sum_abs += fabsf(x[i*qk + j]);
-        }
-        const float d = sum_abs / qk;
-
-        y[i].d = GGML_FP32_TO_FP16(d);
-
-        // Clear all bits first
-        for (int j = 0; j < qk / 8; ++j) {
-            y[i].qs[j] = 0;
-        }
-
-        // Just store sign of each weight directly (no normalization)
-        for (int j = 0; j < qk; ++j) {
-            const int bit_index = j;
-            const int byte_index = bit_index / 8;
-            const int bit_offset = bit_index % 8;
-
-            if (x[i*qk + j] >= 0.0f) {
-                y[i].qs[byte_index] |= (1 << bit_offset);
-            }
-        }
-    }
-}
-
-// reference implementation for deterministic creation of model files
 void quantize_row_q4_0_ref(const float * GGML_RESTRICT x, block_q4_0 * GGML_RESTRICT y, int64_t k) {
     static const int qk = QK4_0;
 

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -963,10 +963,6 @@ static ggml_cgraph * clip_image_build_graph(clip_ctx * ctx, const clip_image_f32
             {
                 builder = std::make_unique<clip_graph_glm4v>(ctx, img);
             } break;
-        case PROJECTOR_TYPE_QWEN3A:
-            {
-                builder = std::make_unique<clip_graph_qwen3a>(ctx, img);
-            } break;
         case PROJECTOR_TYPE_YOUTUVL:
             {
                 builder = std::make_unique<clip_graph_youtuvl>(ctx, img);

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -833,6 +833,27 @@ private:
         slots.clear();
 
         ctx_tgt_seq_rm_type = common_context_can_seq_rm(ctx_tgt);
+
+        // SWA-aware probe fallback. The `common_context_can_seq_rm` probe
+        // does a 2-token test decode that returns `_TYPE_NO` whenever the
+        // first `llama_decode()` call returns nonzero. On SWA-based bodies
+        // (Qwen3.6, gemma-4) the probe's all-zero positions / single-seq
+        // batch can fail validation (M-RoPE position constraints, SWA
+        // window setup edge cases) even though the body would otherwise
+        // be perfectly usable for spec-decode via the checkpoint path
+        // (the `do_checkpoint` block ~1850 lines below already enables
+        // it when `n_swa > 0`). When the probe returns `_TYPE_NO` but
+        // the model declares SWA, demote the probe result to `_TYPE_FULL`
+        // (use checkpoints) rather than disable spec-decode entirely.
+        // This unblocks DFlash speculative decoding on Qwen3.6-class
+        // bodies paired with their community / Eliza-1 distilled drafters.
+        if (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_NO &&
+            llama_model_n_swa(model_tgt) > 0 &&
+            !params_base.swa_full) {
+            SRV_WRN("%s", "seq_rm probe failed but model declares SWA — falling back to checkpoint-mode spec-decode\n");
+            ctx_tgt_seq_rm_type = COMMON_CONTEXT_SEQ_RM_TYPE_FULL;
+        }
+
         if (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_NO) {
             SRV_WRN("%s", "speculative decoding not supported by this context\n");
         }


### PR DESCRIPTION
## Summary

Headline fix is a 21-line patch that makes `--spec-type dflash` actually fire for SWA-based bodies (Qwen3.6, gemma-4, future Eliza-1-27b) — companion to [elizaOS/eliza#7635](https://github.com/elizaOS/eliza/issues/7635).

I tried to runtime-validate the SWA fix on Intel Arc 140V Vulkan against `Qwen3.6-27B Q4_K_M + spiritbuun/Qwen3.6-27B-DFlash-GGUF` and hit a cascade of compile-blockers from the `79079c25e merge: upstream/master into milady/main` commit. **Four of them are 1-2-line fixes that I'm including in this PR** so the change is buildable end-to-end on `milady/main`-equivalent trees. The full tracker for all the merge regressions (including a 7th I couldn't resolve in-session) is at [elizaOS/eliza#7636](https://github.com/elizaOS/eliza/issues/7636).

## Commit-by-commit

```
cadb762da server: SWA-aware fallback for spec-decode probe (--spec-type dflash on Qwen3.6, gemma-4, …)
30f1ad6e5 ggml-quants: remove duplicate quantize_row_q1_0_ref definition (compile-block)
7dea6f0a4 mtmd/clip: drop duplicate PROJECTOR_TYPE_QWEN3A case (compile-block)
85e0a6d3b common: add missing replacements field to common_params_speculative (compile-block)
827747077 common/speculative: bump SPECULATIVE_TYPE_COUNT static_assert from 8 to 9 (compile-block)
```

Each commit body has its own root-cause writeup. Happy to split into separate PRs if maintainers prefer — wanted to keep them stacked so the build progresses through each gate.

### 1. The actual feature (`cadb762da`)

`common_context_can_seq_rm()` does a 2-token probe that classifies the target context as `_TYPE_PART` / `_TYPE_FULL` / `_TYPE_NO`. On SWA bodies the 2-token decode test fails for reasons unrelated to whether spec-decode actually works — M-RoPE position validation, SWA window edge cases. The probe returns `_TYPE_NO`, `tools/server/server-context.cpp:836` disables spec-decode entirely, but lines 2680-2682 already enable `do_checkpoint` when `n_swa > 0`. There's a working code path; just the probe gates the wrong way.

Fix: if probe returns `_TYPE_NO` AND `llama_model_n_swa(model_tgt) > 0` AND not `--swa-full`, demote to `_TYPE_FULL` (use checkpoints).

Non-SWA bodies are unaffected (the demotion only fires when both `_TYPE_NO` AND `n_swa > 0`).

### 2-5. Build-unblocks

These are duplicate definitions / API-renames / missing struct fields the `79079c25e` upstream merge left unreconciled. Diffs are tiny (delete one duplicate definition; add `()` to a function call; add a `std::vector<std::pair<...>>` field; bump a static_assert constant). The commit messages document exactly what each one does and why.

## Verification status

**Patch correctness:** reviewed against the surrounding code paths in `server-context.cpp` lines 833-862 and 2670-2682. The demotion sits inside the existing classification flow without changing any existing branches. `n_swa > 0` is the same predicate the existing `do_checkpoint` enable uses.

**Runtime validation:** **blocked** on regression #7 in [elizaOS/eliza#7636](https://github.com/elizaOS/eliza/issues/7636) (Vulkan `vulkan-shaders-gen` emits zero `.spv` files in the new build tree; build fails at link with ~2,000 undefined references). Without a runnable `llama-server` binary on `d629a3768` + this patch stack, I couldn't drive the 27B + DFlash combo through it to capture `n_drafted` / `n_accept` numbers.

The pre-merge build (`a61c93aaa5` = `v1.2.0-eliza`) is buildable and runs the same 27B + DFlash combo cleanly — but it uses the old `common_speculative_is_compat(ctx)` bool API, not the post-merge `common_context_can_seq_rm` enum API, so this patch doesn't apply there.

Once a maintainer with a fully-clean `milady/main` build env (or once regression #7 lands) confirms a clean compile, the runtime test is the same 27B + DFlash repro that's documented in [elizaOS/eliza#7635](https://github.com/elizaOS/eliza/issues/7635#issuecomment-4437243940). Expected delta: the `seq_rm probe failed but model declares SWA — falling back to checkpoint-mode spec-decode` warning appears in the log, `speculative decoding context initialized` follows, and chat completions return `n_drafted` / `n_accept` keys in their `timings` object.

## Out of scope for this PR

- Per-checkpoint DFlash ring-buffer save/restore (the deeper improvement from `spiritbuun/buun-llama-cpp@9a388b52e`, ~200 LOC).
- Native SWA-aware probe (avoid the demotion entirely by writing a SWA-aware 2-token test).
- Regression #7 (`vulkan-shaders-gen` zero-output failure) — needs maintainer with full build env to diagnose the `--source` vs `--input-dir` CLI shape change or whatever else broke shader-gen.
- AMD XDNA / Qualcomm Hexagon SWA paths.

## Related (downstream eliza repo)

- [elizaOS/eliza#7635](https://github.com/elizaOS/eliza/issues/7635) — the issue this PR's headline commit fixes
- [elizaOS/eliza#7636](https://github.com/elizaOS/eliza/issues/7636) — tracker for the 6 compile-block regressions the upstream merge introduced
- [elizaOS/eliza#7634](https://github.com/elizaOS/eliza/pull/7634) — eliza-side companion (advances the submodule pointer to `d629a3768`; will need a bump to this PR's HEAD once it lands)
- [elizaOS/eliza#7629](https://github.com/elizaOS/eliza/issues/7629) — publication gap for Eliza-1 distilled DFlash drafters (unblocked by this PR's headline once drafters ship)
- [elizaOS/eliza#7631](https://github.com/elizaOS/eliza/issues/7631) — M-RoPE spec-decode gate (sibling failure mode, distinct error path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)