### PR TITLE
server: SWA-aware fallback for --spec-type dflash probe (Qwen3.6, gemma-4)

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -833,6 +833,27 @@ private:
         slots.clear();
 
         ctx_tgt_seq_rm_type = common_context_can_seq_rm(ctx_tgt);
+
+        // SWA-aware probe fallback. The `common_context_can_seq_rm` probe
+        // does a 2-token test decode that returns `_TYPE_NO` whenever the
+        // first `llama_decode()` call returns nonzero. On SWA-based bodies
+        // (Qwen3.6, gemma-4) the probe's all-zero positions / single-seq
+        // batch can fail validation (M-RoPE position constraints, SWA
+        // window setup edge cases) even though the body would otherwise
+        // be perfectly usable for spec-decode via the checkpoint path
+        // (the `do_checkpoint` block ~1850 lines below already enables
+        // it when `n_swa > 0`). When the probe returns `_TYPE_NO` but
+        // the model declares SWA, demote the probe result to `_TYPE_FULL`
+        // (use checkpoints) rather than disable spec-decode entirely.
+        // This unblocks DFlash speculative decoding on Qwen3.6-class
+        // bodies paired with their community / Eliza-1 distilled drafters.
+        if (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_NO &&
+            llama_model_n_swa(model_tgt) > 0 &&
+            !params_base.swa_full) {
+            SRV_WRN("%s", "seq_rm probe failed but model declares SWA — falling back to checkpoint-mode spec-decode\n");
+            ctx_tgt_seq_rm_type = COMMON_CONTEXT_SEQ_RM_TYPE_FULL;
+        }
+
         if (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_NO) {
             SRV_WRN("%s", "speculative decoding not supported by this context\n");
         }


### PR DESCRIPTION
## Summary

21-line patch that makes `--spec-type dflash` actually fire for SWA-based bodies (Qwen3.6, gemma-4, future Eliza-1-27b). Companion to [elizaOS/eliza#7635](https://github.com/elizaOS/eliza/issues/7635).

Single commit. The compile-time regressions from the `79079c25e` upstream/master merge that block building this on `milady/main` are filed separately at #4 so this PR stays a focused review.

## Root cause

`common_context_can_seq_rm()` does a 2-token probe that classifies the target context as `_TYPE_PART` / `_TYPE_FULL` / `_TYPE_NO`. On SWA bodies the 2-token decode test fails for reasons unrelated to whether spec-decode actually works (M-RoPE position validation, SWA window edge cases). The probe returns `_TYPE_NO`, `tools/server/server-context.cpp:836` disables spec-decode entirely. But lines 2680-2682 already enable `do_checkpoint` when `n_swa > 0` — there is a working code path; the probe just gates the wrong way for SWA.

## Fix

If probe returns `_TYPE_NO` AND `llama_model_n_swa(model_tgt) > 0` AND not `--swa-full`, demote to `_TYPE_FULL` (use checkpoints):

```cpp
if (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_NO &&
    llama_model_n_swa(model_tgt) > 0 &&
    !params_base.swa_full) {
    SRV_WRN("%s", "seq_rm probe failed but model declares SWA — falling back to checkpoint-mode spec-decode\n");
    ctx_tgt_seq_rm_type = COMMON_CONTEXT_SEQ_RM_TYPE_FULL;
}
```

Non-SWA bodies are unaffected — the demotion only fires when both `_TYPE_NO` AND `n_swa > 0`.

## Verification

**Patch correctness:** reviewed against the surrounding code paths in `server-context.cpp` lines 833-862 and 2670-2682. The demotion sits inside the existing classification flow without changing any existing branches. `n_swa > 0` is the same predicate the existing `do_checkpoint` enable uses.

**Runtime validation:** blocked on the compile-time regressions in #4 (Vulkan `vulkan-shaders-gen` regression in the post-merge tree). The pre-merge `v1.2.0-eliza` build is runnable but uses the old `common_speculative_is_compat(ctx)` bool API, not the post-merge `common_context_can_seq_rm` enum API, so this patch does not apply there.

Once the compile-fix PR lands (or a maintainer with a clean `milady/main` build env confirms), the runtime repro is in [elizaOS/eliza#7635](https://github.com/elizaOS/eliza/issues/7635#issuecomment-4437243940). Expected delta: the `seq_rm probe failed but model declares SWA — falling back to checkpoint-mode spec-decode` warning appears in the log, `speculative decoding context initialized` follows, and chat completions return `n_drafted` / `n_accept` keys in their `timings` object.

## Out of scope

- Native SWA-aware probe (would avoid the demotion entirely by writing an SWA-aware 2-token test).
- Per-checkpoint DFlash ring-buffer save/restore (deeper improvement from `spiritbuun/buun-llama-cpp@9a388b52e`, ~200 LOC).
- AMD XDNA / Qualcomm Hexagon SWA paths.

## Related

- [elizaOS/eliza#7635](https://github.com/elizaOS/eliza/issues/7635) — the issue this PR fixes
- #4 — sibling PR with 4 compile-block fixes needed to build this on `milady/main`
- [elizaOS/eliza#7636](https://github.com/elizaOS/eliza/issues/7636) — tracker for the full set of upstream/master merge regressions
- [elizaOS/eliza#7629](https://github.com/elizaOS/eliza/issues/7629) — Eliza-1 distilled DFlash drafter publication gap (unblocked once drafters ship)
- [elizaOS/eliza#7631](https://github.com/elizaOS/eliza/issues/7631) — M-RoPE spec-decode gate (sibling failure mode, distinct error path)
