### PR TITLE
unblock 8 compile-time regressions from the upstream/master merge

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -353,6 +353,16 @@ struct common_params_speculative {
 
     common_params_speculative_ngram_cache ngram_cache;
 
+    // Cross-vocab token replacement pairs for spec-decode: when the
+    // target and draft models have different tokenizers, replace
+    // occurrences of `first` (target-tokenizer string) with `second`
+    // (draft-tokenizer string) in the prompt fed to the draft model.
+    // Wired by the `--spec-replace TARGET DRAFT` CLI flag and consumed
+    // by `common_speculative_apply_replacements()`. Required by the
+    // upstream/master speculative-decode rewrite that landed in
+    // 79079c25e but not added to this struct as part of that merge.
+    std::vector<std::pair<std::string, std::string>> replacements;
+
     bool has_dft() const {
         return !draft.mparams.path.empty() || !draft.mparams.hf_repo.empty();
     }

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -889,7 +889,11 @@ common_speculative * common_speculative_init(common_params_speculative & params,
         bool has_ngram_mod     = (enabled_configs & (1u << COMMON_SPECULATIVE_TYPE_NGRAM_MOD));
 
         // when adding a new type - update here the logic above
-        static_assert(COMMON_SPECULATIVE_TYPE_COUNT == 8);
+        // Bump: DFLASH was added to the enum (between NGRAM_CACHE and
+        // COUNT) so COUNT is now 9. DFLASH dispatches through has_draft
+        // (see enum comment: "behaves like DRAFT when -md is provided")
+        // so it doesn't need a separate has_* bool here.
+        static_assert(COMMON_SPECULATIVE_TYPE_COUNT == 9);
 
         // this list here defines the priority of the speculators
         // the one with highest priority are listed first

--- a/ggml/src/ggml-quants.c
+++ b/ggml/src/ggml-quants.c
@@ -235,41 +235,6 @@ void quantize_row_q1_0_g128_ref(const float * GGML_RESTRICT x, block_q1_0_g128 *
 }
 
 // reference implementation for deterministic creation of model files
-void quantize_row_q1_0_ref(const float * GGML_RESTRICT x, block_q1_0 * GGML_RESTRICT y, int64_t k) {
-    static const int qk = QK1_0;
-
-    assert(k % qk == 0);
-
-    const int nb = k / qk;
-
-    for (int i = 0; i < nb; i++) {
-        float sum_abs = 0.0f;
-        for (int j = 0; j < qk; j++) {
-            sum_abs += fabsf(x[i*qk + j]);
-        }
-        const float d = sum_abs / qk;
-
-        y[i].d = GGML_FP32_TO_FP16(d);
-
-        // Clear all bits first
-        for (int j = 0; j < qk / 8; ++j) {
-            y[i].qs[j] = 0;
-        }
-
-        // Just store sign of each weight directly (no normalization)
-        for (int j = 0; j < qk; ++j) {
-            const int bit_index = j;
-            const int byte_index = bit_index / 8;
-            const int bit_offset = bit_index % 8;
-
-            if (x[i*qk + j] >= 0.0f) {
-                y[i].qs[byte_index] |= (1 << bit_offset);
-            }
-        }
-    }
-}
-
-// reference implementation for deterministic creation of model files
 void quantize_row_q4_0_ref(const float * GGML_RESTRICT x, block_q4_0 * GGML_RESTRICT y, int64_t k) {
     static const int qk = QK4_0;
 

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -1002,14 +1002,6 @@ static const struct ggml_type_traits type_traits[GGML_TYPE_COUNT] = {
         .type_size                = 0,
         .is_quantized             = false,
     },
-    [45] = { // RESERVED — was GGML_TYPE_COUNT pre-QJL; left as a hole so a
-             // GGUF that recorded this id under the old build is unambiguously
-             // not a QJL block at runtime.
-        .type_name                = "TYPE_45 RESERVED (pre-QJL GGML_TYPE_COUNT)",
-        .blck_size                = 0,
-        .type_size                = 0,
-        .is_quantized             = false,
-    },
 };
 
 const struct ggml_type_traits * ggml_get_type_traits(enum ggml_type type) {

--- a/src/models/dflash_draft.cpp
+++ b/src/models/dflash_draft.cpp
@@ -98,8 +98,8 @@ llm_build_dflash_draft::llm_build_dflash_draft(
         const llama_model & model,
         const llm_graph_params & params) :
     llm_graph_context(params) {
-    const int64_t n_embd_head = hparams.n_embd_head_v;
-    GGML_ASSERT(n_embd_head == hparams.n_embd_head_k);
+    const int64_t n_embd_head = hparams.n_embd_head_v();
+    GGML_ASSERT(n_embd_head == hparams.n_embd_head_k());
 
     int64_t ctx_len = cross && cross->n_enc > 0 ? cross->n_enc : LLAMA_DFLASH_PER_SLOT_CTX_LOCAL;
     const int64_t max_ctx = dflash_max_cross_ctx();

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -963,10 +963,6 @@ static ggml_cgraph * clip_image_build_graph(clip_ctx * ctx, const clip_image_f32
             {
                 builder = std::make_unique<clip_graph_glm4v>(ctx, img);
             } break;
-        case PROJECTOR_TYPE_QWEN3A:
-            {
-                builder = std::make_unique<clip_graph_qwen3a>(ctx, img);
-            } break;
         case PROJECTOR_TYPE_YOUTUVL:
             {
                 builder = std::make_unique<clip_graph_youtuvl>(ctx, img);

--- a/tools/omnivoice/src/dac-decoder.h
+++ b/tools/omnivoice/src/dac-decoder.h
@@ -348,21 +348,16 @@ static struct ggml_tensor * dac_conv_t1d(struct ggml_context * ctx,
                                          int                   pad,
                                          int                   oc,
                                          int                   output_pad) {
-    // 1. transpose x: [T_in, IC] -> [IC, T_in] (contiguous copy)
-    struct ggml_tensor * xt = ggml_cont(ctx, ggml_transpose(ctx, x));
-
-    // 2. mul_mat contracts over IC: col [K*OC, T_in]
-    struct ggml_tensor * col = ggml_mul_mat(ctx, w, xt);
-
-    // 3. col2im_1d scatters into [T_out_no_op, OC] with T_out_no_op = (T_in - 1)*stride + K - 2*pad
-    struct ggml_tensor * y = ggml_col2im_1d(ctx, col, stride, oc, pad);
-
-    // 4. reference ConvTranspose1d output_padding = right-pad with zeros along T axis
+    (void) oc;
+    // ggml_col2im_1d was removed in the upstream/master merge (79079c25e).
+    // Shaw's d629a3768 ("conv_transpose_1d now has Metal kernel") names
+    // ggml_conv_transpose_1d as the replacement primitive; the CPU-side body
+    // wasn't migrated. This collapses the legacy 5-step body into the single
+    // upstream call.
+    struct ggml_tensor * y = ggml_conv_transpose_1d(ctx, w, x, stride, pad, /*dilation*/ 1);
     if (output_pad > 0) {
         y = ggml_pad(ctx, y, output_pad, 0, 0, 0);
     }
-
-    // 5. add bias
     if (b) {
         struct ggml_tensor * b2d = ggml_reshape_2d(ctx, b, 1, b->ne[0]);
         y                        = ggml_add(ctx, y, b2d);


### PR DESCRIPTION
## Summary

Eight 1-2-line fixes that unblock building `milady/main` after the `79079c25e merge: upstream/master into milady/main` commit. Splits the build-unblocks out of #3 so each PR stays focused on one concern.

Full regression tracker (including the remaining `vulkan-shaders-gen` zero-output failure that needs maintainer access) is at [elizaOS/eliza#7636](https://github.com/elizaOS/eliza/issues/7636).

## Commits

```
30f1ad6e5  ggml-quants: remove duplicate quantize_row_q1_0_ref definition
7dea6f0a4  mtmd/clip: drop duplicate PROJECTOR_TYPE_QWEN3A case
85e0a6d3b  common: add missing replacements field to common_params_speculative
827747077  common/speculative: bump SPECULATIVE_TYPE_COUNT static_assert from 8 to 9
16b29996f  src/models/dflash_draft.cpp: n_embd_head_v / n_embd_head_k method-call upgrade
78c4fb190  tools/omnivoice: migrate dac_conv_t1d to ggml_conv_transpose_1d
d242e8488  ggml: drop stale [45] RESERVED type_traits entry that silently overrides TBQ4_0
e0b9d890c  ggml-quants: add missing quantize_row_q1_0_g32_ref body
```

Each commit body has its own root-cause writeup. The diffs are tiny: delete one duplicate definition, drop one duplicate `case` label, add a `std::vector<std::pair<...>>` field initialization, bump a static_assert constant, add `()` to two method calls, replace one 5-step custom op with one upstream primitive call, delete one stale 8-line designated-initializer block.

The final commit also fixes a silent runtime bug — the stale `[45] = { RESERVED }` block was overriding the proper `[GGML_TYPE_TBQ4_0]` traits, so any TBQ4_0 weight at runtime would see `.blck_size = 0` and divide-by-zero in `ggml_row_size`.

## Why these specifically

The upstream merge brought in new code that collided with existing milady-side additions (Q1_0 quant, QWEN3A projector, speculative params struct, SPECULATIVE_TYPE enum, hparams API surface, removed ggml ops). Each of these six sites compiles a redeclaration / missing field / off-by-one count / API drift / removed-op reference — all caught at the compile stage, none are functional changes.

## Verification

CPU-only build (`-DGGML_VULKAN=OFF -DGGML_CUDA=OFF -DGGML_METAL=OFF -DLLAMA_BUILD_OMNIVOICE=ON`) reaches `[100%] Built target omnivoice_lib` on this branch HEAD (`d242e8488`). All three runtime-relevant regressions (`ggml_col2im_1d` removal, `n_embd_head_v/k` API change, and the `[45]` type-traits override) were confirmed to break the build on `milady/main` (`d629a3768`) without these patches. The `[45]` override-init regression is also a runtime bug — see commit `d242e8488` for details.

The dac-decoder migration preserves shape semantics but has not been numerically validated against the legacy 5-step body on real DAC GGUF weights — that needs a maintainer with the bundled `Serveurperso/OmniVoice-GGUF` weights to confirm output parity at the audio-codec level.

What this PR does NOT fix:
- Regression #7 in [#7636](https://github.com/elizaOS/eliza/issues/7636): Vulkan `vulkan-shaders-gen` produces zero `.spv` output files at generate time, blocking every Vulkan-backend build (fused and non-fused). Symptom: 2000+ "Error opening file: ...spv (No such file or directory)" lines, link fails with ~2000 undefined references. Needs maintainer to debug the CLI-shape change or output-dir resolution in `ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp`.

## Related

- #3 — sibling PR with the actual SWA spec-decode fix this set unblocks
- [elizaOS/eliza#7636](https://github.com/elizaOS/eliza/issues/7636) — full tracker for the upstream/master merge regressions
- [elizaOS/eliza#7634](https://github.com/elizaOS/eliza/pull/7634) — eliza-side companion (advances the submodule pointer; will need a bump to this PR's HEAD once it lands)
