### PR TITLE
Post-merge follow-up: 3 more compile/regression fixes (q1_0_g32_ref body, qjl empty-TU, vulkan-shaders-gen exit code)

### DIFF
--- a/ggml/src/ggml-cpu/qjl/qjl_quantize_avx2.c
+++ b/ggml/src/ggml-cpu/qjl/qjl_quantize_avx2.c
@@ -108,3 +108,8 @@ void qjl_dequantize_row_avx2(const qjl_block_qjl1_256 *blk, const float *prj,
 }
 
 #endif /* __AVX2__ */
+
+/* On non-AVX2 targets the entire body above preprocesses out — give the
+ * translation unit at least one declaration so -Werror=pedantic doesn't
+ * trip on ISO C's empty-TU rule. */
+typedef int qjl_quantize_avx2_tu_marker_t;

--- a/ggml/src/ggml-cpu/qjl/qjl_quantize_neon.c
+++ b/ggml/src/ggml-cpu/qjl/qjl_quantize_neon.c
@@ -105,3 +105,8 @@ void qjl_dequantize_row_neon(const qjl_block_qjl1_256 *blk, const float *prj,
 }
 
 #endif /* __ARM_NEON */
+
+/* On non-NEON targets the entire body above preprocesses out — give the
+ * translation unit at least one declaration so -Werror=pedantic doesn't
+ * trip on ISO C's empty-TU rule. */
+typedef int qjl_quantize_neon_tu_marker_t;

--- a/ggml/src/ggml-cpu/qjl/qjl_score_avx2.c
+++ b/ggml/src/ggml-cpu/qjl/qjl_score_avx2.c
@@ -124,3 +124,8 @@ void qjl_score_qk_avx2(const float *q_sketch,
 }
 
 #endif /* __AVX2__ */
+
+/* On non-AVX2 targets the entire body above preprocesses out — give the
+ * translation unit at least one declaration so -Werror=pedantic doesn't
+ * trip on ISO C's empty-TU rule. */
+typedef int qjl_score_avx2_tu_marker_t;

--- a/ggml/src/ggml-cpu/qjl/qjl_score_avxvnni.c
+++ b/ggml/src/ggml-cpu/qjl/qjl_score_avxvnni.c
@@ -149,3 +149,8 @@ void qjl_score_qk_i8_avxvnni(const qjl_i8_sketch_256 *q_sketch_i8,
 }
 
 #endif /* AVX-VNNI */
+
+/* On non-AVX-VNNI targets the entire body above preprocesses out — give
+ * the translation unit at least one declaration so -Werror=pedantic
+ * doesn't trip on ISO C's empty-TU rule. */
+typedef int qjl_score_avxvnni_tu_marker_t;

--- a/ggml/src/ggml-cpu/qjl/qjl_score_dotprod.c
+++ b/ggml/src/ggml-cpu/qjl/qjl_score_dotprod.c
@@ -78,3 +78,8 @@ void qjl_score_qk_i8_dotprod(const qjl_i8_sketch_256 *q_sketch_i8,
 }
 
 #endif /* __aarch64__ && __ARM_FEATURE_DOTPROD */
+
+/* On non-dotprod-capable arm64 targets the entire body above preprocesses
+ * out — give the translation unit at least one declaration so
+ * -Werror=pedantic doesn't trip on ISO C's empty-TU rule. */
+typedef int qjl_score_dotprod_tu_marker_t;

--- a/ggml/src/ggml-cpu/qjl/qjl_score_neon.c
+++ b/ggml/src/ggml-cpu/qjl/qjl_score_neon.c
@@ -64,3 +64,8 @@ void qjl_score_qk_neon(const float *q_sketch,
 }
 
 #endif /* __ARM_NEON */
+
+/* On non-NEON targets the entire body above preprocesses out — give the
+ * translation unit at least one declaration so -Werror=pedantic doesn't
+ * trip on ISO C's empty-TU rule. */
+typedef int qjl_score_neon_tu_marker_t;

--- a/ggml/src/ggml-quants.c
+++ b/ggml/src/ggml-quants.c
@@ -200,6 +200,40 @@ void quantize_row_q1_0_ref(const float * GGML_RESTRICT x, block_q1_0 * GGML_REST
     }
 }
 
+void quantize_row_q1_0_g32_ref(const float * GGML_RESTRICT x, block_q1_0_g32 * GGML_RESTRICT y, int64_t k) {
+    static const int qk = QK1_0_g32;
+
+    assert(k % qk == 0);
+
+    const int nb = k / qk;
+
+    for (int i = 0; i < nb; i++) {
+        float sum_abs = 0.0f;
+        for (int j = 0; j < qk; j++) {
+            sum_abs += fabsf(x[i*qk + j]);
+        }
+        const float d = sum_abs / qk;
+
+        y[i].d = GGML_FP32_TO_FP16(d);
+
+        // Clear all bits first
+        for (int j = 0; j < qk / 8; ++j) {
+            y[i].qs[j] = 0;
+        }
+
+        // Just store sign of each weight directly (no normalization)
+        for (int j = 0; j < qk; ++j) {
+            const int bit_index = j;
+            const int byte_index = bit_index / 8;
+            const int bit_offset = bit_index % 8;
+
+            if (x[i*qk + j] >= 0.0f) {
+                y[i].qs[byte_index] |= (1 << bit_offset);
+            }
+        }
+    }
+}
+
 void quantize_row_q1_0_g128_ref(const float * GGML_RESTRICT x, block_q1_0_g128 * GGML_RESTRICT y, int64_t k) {
     static const int qk = QK1_0_g128;
 

--- a/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
@@ -78,7 +78,7 @@ enum MatMulIdType {
 
 namespace {
 
-void execute_command(std::vector<std::string>& command, std::string& stdout_str, std::string& stderr_str) {
+int execute_command(std::vector<std::string>& command, std::string& stdout_str, std::string& stderr_str) {
 #ifdef _WIN32
     HANDLE stdout_read, stdout_write;
     HANDLE stderr_read, stderr_write;
@@ -127,8 +127,11 @@ void execute_command(std::vector<std::string>& command, std::string& stdout_str,
     CloseHandle(stdout_read);
     CloseHandle(stderr_read);
     WaitForSingleObject(pi.hProcess, INFINITE);
+    DWORD exit_code = 0;
+    GetExitCodeProcess(pi.hProcess, &exit_code);
     CloseHandle(pi.hProcess);
     CloseHandle(pi.hThread);
+    return (int) exit_code;
 #else
     int stdout_pipe[2];
     int stderr_pipe[2];
@@ -175,9 +178,15 @@ void execute_command(std::vector<std::string>& command, std::string& stdout_str,
 
         close(stdout_pipe[0]);
         close(stderr_pipe[0]);
-        waitpid(pid, nullptr, 0);
+        int status = 0;
+        waitpid(pid, &status, 0);
+        if (WIFEXITED(status)) {
+            return WEXITSTATUS(status);
+        }
+        return -1;
     }
 #endif
+    return -1;
 }
 
 bool directory_exists(const std::string& path) {
@@ -371,14 +380,21 @@ void string_to_spv_func(std::string name, std::string in_path, std::string out_p
         // }
         // std::cout << std::endl;
 
-        execute_command(cmd, stdout_str, stderr_str);
-        if (!stderr_str.empty()) {
-            std::cerr << "cannot compile " << name << "\n\n";
+        int rc = execute_command(cmd, stdout_str, stderr_str);
+        // glslc may write deprecation warnings to stderr even on a successful
+        // compile — gate the failure path on the exit code, not on stderr
+        // being non-empty. Keep surfacing any diagnostics either way so the
+        // build log still shows them. (Regression #7 / elizaOS/eliza#7636.)
+        if (rc != 0) {
+            std::cerr << "cannot compile " << name << " (glslc exit " << rc << ")\n\n";
             for (const auto& part : cmd) {
                 std::cerr << part << " ";
             }
             std::cerr << "\n\n" << stderr_str << std::endl;
             return;
+        }
+        if (!stderr_str.empty()) {
+            std::cerr << "glslc diagnostics for " << name << ":\n" << stderr_str;
         }
 
         if (dep_file) {


### PR DESCRIPTION
Follow-up to #4 (just merged). Three additional compile-blockers and one
runtime hazard surfaced after attempting an end-to-end build on the
post-#4 tree. Filing them as a separate PR so the review surface stays
focused.

Full context: [elizaOS/eliza#7636](https://github.com/elizaOS/eliza/issues/7636).

## Commits

| File | Symptom | Reg # |
|---|---|---|
| `ggml/src/ggml-quants.c` | `Undefined reference to quantize_row_q1_0_g32_ref` link failure on every target | #11 |
| `ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp` | Vulkan build emits 1-of-hundreds .spv files; downstream link cascades w/ ~2000 undefined refs | #7 |
| `ggml/src/ggml-cpu/qjl/qjl_{quantize,score}_{avx2,avxvnni,neon,dotprod}.c` (×6) | `ISO C forbids an empty translation unit [-Werror=pedantic]` on the opposite-arch host (`ubuntu-cpu x64` job fails at `qjl_quantize_avx2.c:111`) | #12 |

## Verification

CPU-only build (`-DGGML_VULKAN=OFF -DGGML_CUDA=OFF -DGGML_METAL=OFF -DLLAMA_BUILD_OMNIVOICE=ON`) reaches `100% Built target llama-server` on macOS arm64 against this branch HEAD; the pre-fix tree (post-#4) link-fails on `quantize_row_q1_0_g32_ref`.

The vulkan-shaders-gen change preserves byte-for-byte existing behavior on glslc versions that don't emit stderr on success (verified locally — same 16 `.spv` files produced for `add.comp`). It additionally tolerates glslc versions that emit deprecation warnings on success — the failure path now triggers only on `rc != 0`, and any stderr output is surfaced as a `glslc diagnostics for <name>:` line so the build log isn't muted.

The qjl typedef markers are inert: unused, eliminated by the linker, never reach any header.

## Out of scope

- The vulkan-shaders-gen file is byte-identical to upstream `ggml-org/master` (zero diff before this PR). The hardening is forward-port-worthy — happy to send it upstream as a separate PR.
- DAC numerical parity (regression #8 in #4) still needs maintainer with the bundled `Serveurperso/OmniVoice-GGUF` weights to confirm audio-codec output parity. Unchanged here.

🤖 Co-authored-by: Claude Opus 4.7 (1M context)