### PR TITLE
common/speculative: reject M-RoPE bodies upfront (elizaOS/eliza#7631)

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -44,6 +44,29 @@ struct common_speculative_config {
 static bool common_speculative_are_compatible(
     const llama_model * model_tgt,
     const llama_model * model_dft) {
+    // M-RoPE rejection guard. The spec-decode harness re-feeds the boundary
+    // token (the last token of the accepted prefix) alongside the K drafts
+    // so the target can score them. On M-RoPE bodies, the position-validation
+    // path in src/llama-batch.cpp requires *strict* monotone advancement
+    // (`KV_max < first_new_pos`) — but the boundary re-feed lands at
+    // `first_new_pos == KV_max`, so every drafted batch is rejected and
+    // acceptance collapses (~9% in the wild; see elizaOS/eliza#7631).
+    // Rather than silently degenerate to <1 t/s with a per-batch error
+    // loop, reject the body+drafter pair here. The server then emits the
+    // existing "speculative decoding not supported by this context"
+    // warning and falls back to body-only inference at full throughput.
+    // This guard only fires on M-RoPE / I-MRoPE target models — every
+    // other rope type is unaffected.
+    const llama_rope_type rope_tgt = llama_model_rope_type(model_tgt);
+    if (rope_tgt == LLAMA_ROPE_TYPE_MROPE || rope_tgt == LLAMA_ROPE_TYPE_IMROPE) {
+        LOG_WRN("%s: target model uses M-RoPE — speculative decoding is not "
+                "currently supported for M-RoPE bodies due to a strict "
+                "monotone-position requirement in src/llama-batch.cpp that "
+                "rejects the harness's boundary-token re-feed pattern. "
+                "See elizaOS/eliza#7631.\n", __func__);
+        return false;
+    }
+
     const llama_vocab * vocab_tgt = llama_model_get_vocab(model_tgt);
     const llama_vocab * vocab_dft = llama_model_get_vocab(model_dft);
 


### PR DESCRIPTION
## Summary

Reject the body+drafter pair upfront when the target model uses M-RoPE (or I-MRoPE) RoPE, rather than silently degenerating to ~9% acceptance and per-batch error spam. The spec-decode harness re-feeds the boundary token of the accepted prefix alongside its K drafts, but `src/llama-batch.cpp`'s position-validation path requires *strict* monotone advancement (`KV_max < first_new_pos`) for M-RoPE bodies — so every drafted batch lands on `first_new_pos == KV_max` and is rejected. The harness keeps re-feeding single tokens, the error message fires per-batch, and effective throughput collapses below body-only.

Downstream symptom (Qwen3.5-9B body + Qwen3.5-0.8B drafter, original Vulkan repro in the issue body): `init: the tokens of sequence 0 in the input batch have inconsistent sequence positions ... for M-RoPE, it is required that the position satisfies: X < Y` fires continuously; `n_accept / n_drafted = 21 / 222 = 9.5%`; tg drops to 0.33 t/s.

After this patch, `common_speculative_are_compatible` returns `false` upfront with a clear `LOG_WRN` diagnostic, the harness's existing vocab-mismatch / unsupported-context handling kicks in, and the server falls back to body-only inference at full throughput. No silent degradation, no per-batch error loop.

## Root cause one-liner

M-RoPE position validation in `src/llama-batch.cpp` requires strict monotone advancement; the spec-decode harness's boundary-token re-feed lands at exactly `KV_max`, so every drafted batch is rejected.

## Patch

`common/speculative.cpp` — add an M-RoPE guard at the top of `common_speculative_are_compatible`. Calls `llama_model_rope_type(model_tgt)`; if the result is `LLAMA_ROPE_TYPE_MROPE` or `LLAMA_ROPE_TYPE_IMROPE`, logs a `LOG_WRN` and returns `false`. Non-M-RoPE bodies are unaffected (the existing vocab compatibility checks run unchanged).

23 lines added, 0 removed. Same file, single function, scoped insertion at the top of the body.

## CUDA hardware validation

Built CUDA `llama-server` + `llama-speculative-simple` against this branch on RTX 5080 (Blackwell, sm_120, 16 GB VRAM), driver 580.142, nvcc 12.8 (`--generate-code=arch=compute_120a,code=[compute_120a,sm_120a]`), gcc-12 host, Ubuntu 24.04.

**Repro (target: M-RoPE Qwen3.5-4B body + same-family Qwen3.5 drafter):**

```
llama-speculative-simple \
  -m Qwen_Qwen3.5-4B-Q4_K_M.gguf \
  -md qwen3.5-4b-dflash-drafter-q4.repaired.gguf \
  --spec-draft-n-min 2 --spec-draft-n-max 8 \
  -ngl 99 -ngld 99 -c 1024 -n 20 \
  -p "Hello."
```

Model-load logs confirm the body is M-RoPE:

```
print_info: rope type             = 40    # LLAMA_ROPE_TYPE_MROPE
print_info: mrope sections        = [11, 11, 10, 0]
```

**Patched-code output (the new guard log line):**

```
common_speculative_are_compatible: target model uses M-RoPE — speculative decoding is not currently supported for M-RoPE bodies due to a strict monotone-position requirement in src/llama-batch.cpp that rejects the harness's boundary-token re-feed pattern. See elizaOS/eliza#7631.
common_speculative_state_draft: the target and draft vocabs are not compatible
```

The harness exits cleanly with no per-batch `init: the tokens of sequence 0 ...` error loop and no degenerate ~9% acceptance run. This is the intended behaviour: surface the incompatibility immediately, do not silently degrade.

## Companion

- Downstream issue: [elizaOS/eliza#7631](https://github.com/elizaOS/eliza/issues/7631) (this PR is the §B-A patch from the static-review comment in that thread)
- Companion SWA fix on the same fork: [elizaOS/llama.cpp#3](https://github.com/elizaOS/llama.cpp/pull/3) / [`cadb762da`](https://github.com/elizaOS/llama.cpp/commit/cadb762da) — validates the same approach (surface the incompatibility cleanly rather than degenerate silently). CUDA-validated alongside this patch and reported back on [#7635](https://github.com/elizaOS/eliza/issues/7635).

## Not touched here

This patch only changes the spec-decode acceptance gate. The underlying M-RoPE position-validation tolerance question (whether `src/llama-batch.cpp` should allow boundary-token re-feed for M-RoPE bodies) is the deeper §B-B change in the issue thread; this PR is the §B-A patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
