### PR TITLE
fix(speculative): also reject M-RoPE bodies for DFLASH spec-type

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -78,8 +78,16 @@ static bool common_speculative_are_compatible(
         return false;
     }
 
+    // M-RoPE bodies are incompatible with the draft-batch position-stepping
+    // pattern used by common_speculative_state_draft: it advances 1-D positions
+    // via dp.n_past + i, which collides with the body's M-RoPE batch validator
+    // (src/llama-batch.cpp) requiring strict monotone X < Y positions. DFLASH
+    // is an alias for DRAFT (see common.h: "behaves like DRAFT when -md is
+    // provided") and dispatches through the same impl, so it hits the same
+    // rejection loop. Reject both upfront rather than degenerating to ~9%
+    // acceptance with per-batch errors. See elizaOS/eliza#7631.
     const llama_rope_type rope_type_tgt = llama_model_rope_type(model_tgt);
-    if (spec_type == COMMON_SPECULATIVE_TYPE_DRAFT &&
+    if ((spec_type == COMMON_SPECULATIVE_TYPE_DRAFT || spec_type == COMMON_SPECULATIVE_TYPE_DFLASH) &&
         (rope_type_tgt == LLAMA_ROPE_TYPE_MROPE || rope_type_tgt == LLAMA_ROPE_TYPE_IMROPE)) {
         LOG_WRN("%s: target model uses M-RoPE, which is not currently compatible with "
                 "speculative decoding because the target batch validator requires strict "


### PR DESCRIPTION
## Summary

Commit [`3b10c1c971`](https://github.com/elizaOS/llama.cpp/commit/3b10c1c971) ("fix(dflash): propagate spec type through speculative pipeline") restricted the M-RoPE rejection in `common_speculative_are_compatible()` to only `COMMON_SPECULATIVE_TYPE_DRAFT`, letting `COMMON_SPECULATIVE_TYPE_DFLASH` bypass it.

But per [`common.h:167`](common/common.h#L167), DFLASH "behaves like DRAFT when -md is provided" and dispatches through the same `common_speculative_state_draft` impl, which uses 1-D `dp.n_past + i` position stepping. The body's M-RoPE batch validator at [`src/llama-batch.cpp:265-273`](src/llama-batch.cpp#L265) requires strict monotone X < Y positions regardless of which `spec_type` the harness was configured with — so DFLASH on an M-RoPE body hits the same per-batch error loop the DRAFT path was rejected for (acceptance collapses to ~9%, see [elizaOS/eliza#7631](https://github.com/elizaOS/eliza/issues/7631)).

This patch extends the rejection to DFLASH so users get a clean upfront warning and fall back to body-only inference at full speed instead of degenerating silently.

## Why this is the right fix for now

The deeper fix — making the spec-decode harness M-RoPE-aware so it can advance the 4-D position track properly — is still pending and tracked in #7631's "Suggested fixes" section. Until that lands, both DRAFT and DFLASH on M-RoPE bodies are equally broken; this just makes the failure visible in both cases instead of just one.

## Test plan

- [x] Configure + build `llama-speculative-simple` + `llama-common` on macOS Metal (cmake 4.0.3, Apple clang). Clean compile, no warnings on `speculative.cpp`.
- [x] Static call-graph check: the only call site is the `common_speculative_state_draft` constructor, which receives `type` from `common_speculative_init`'s `config.type` — the DRAFT-vs-DFLASH discriminator. Single point of enforcement.
- [ ] Runtime repro on Vulkan/CUDA with a Qwen3.5 body + Qwen3.5 drafter via `llama-server --spec-type dflash` to confirm the rejection warning fires and inference falls back to body-only at expected speed (no GPU available here — same caveat as the static-review comment on #7631).

Refs: elizaOS/eliza#7631

🤖 Generated with [Claude Code](https://claude.com/claude-code)