### PR TITLE
[codex] Validate fused DFlash native stack on latest main

### DIFF
--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -1157,21 +1157,29 @@ json oaicompat_chat_params_parse(
     // json_schema fallback: if the chat template did not produce a grammar, pass json_schema
     // through to server-task.cpp and skip template grammar artifacts to avoid conflicts.
     bool json_schema_passthrough = !json_schema.is_null() && chat_params.grammar.empty();
+    const bool custom_grammar_passthrough = !grammar.empty() && chat_params.grammar == grammar;
 
     if (json_schema_passthrough) {
         llama_params["json_schema"] = json_schema;
     } else {
         if (!chat_params.grammar.empty()) {
-            llama_params["grammar"]      = chat_params.grammar;
-            llama_params["grammar_type"] = std::string("tool_calls");
+            llama_params["grammar"] = chat_params.grammar;
+            if (!custom_grammar_passthrough) {
+                llama_params["grammar_type"] = std::string("tool_calls");
+            }
         }
-        llama_params["grammar_lazy"] = chat_params.grammar_lazy;
-        auto grammar_triggers        = json::array();
-        for (const auto & trigger : chat_params.grammar_triggers) {
-            server_grammar_trigger ct(trigger);
-            grammar_triggers.push_back(ct.to_json());
+        if (custom_grammar_passthrough) {
+            llama_params["grammar_lazy"] = json_value(body, "grammar_lazy", false);
+            llama_params["grammar_triggers"] = json_value(body, "grammar_triggers", json::array());
+        } else {
+            llama_params["grammar_lazy"] = chat_params.grammar_lazy;
+            auto grammar_triggers        = json::array();
+            for (const auto & trigger : chat_params.grammar_triggers) {
+                server_grammar_trigger ct(trigger);
+                grammar_triggers.push_back(ct.to_json());
+            }
+            llama_params["grammar_triggers"]  = grammar_triggers;
         }
-        llama_params["grammar_triggers"]  = grammar_triggers;
         llama_params["preserved_tokens"]  = chat_params.preserved_tokens;
     }
     llama_params["generation_prompt"] = json_schema_passthrough ? "" : chat_params.generation_prompt;

--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -10,6 +10,7 @@
 #include <nlohmann/json.hpp>
 
 #include <string>
+#include <stdexcept>
 #include <vector>
 #include <cinttypes>
 
@@ -65,7 +66,23 @@ struct server_grammar_trigger {
     server_grammar_trigger() = default;
     server_grammar_trigger(const common_grammar_trigger & value) : value(value) {}
     server_grammar_trigger(const json & in) {
-        value.type = (common_grammar_trigger_type) in.at("type").get<int>();
+        const auto & type = in.at("type");
+        if (type.is_string()) {
+            const std::string type_str = type.get<std::string>();
+            if (type_str == "token") {
+                value.type = COMMON_GRAMMAR_TRIGGER_TYPE_TOKEN;
+            } else if (type_str == "word") {
+                value.type = COMMON_GRAMMAR_TRIGGER_TYPE_WORD;
+            } else if (type_str == "pattern") {
+                value.type = COMMON_GRAMMAR_TRIGGER_TYPE_PATTERN;
+            } else if (type_str == "pattern_full" || type_str == "pattern-full") {
+                value.type = COMMON_GRAMMAR_TRIGGER_TYPE_PATTERN_FULL;
+            } else {
+                throw std::runtime_error("Unknown grammar trigger type: " + type_str);
+            }
+        } else {
+            value.type = (common_grammar_trigger_type) type.get<int>();
+        }
         value.value = in.at("value").get<std::string>();
         if (value.type == COMMON_GRAMMAR_TRIGGER_TYPE_TOKEN) {
             value.token = (llama_token) in.at("token").get<int>();


### PR DESCRIPTION
## Summary

Updates the fused DFlash/OmniVoice native branch to the current `main` lineage and validates the Linux Vulkan fused artifact on the Lunar Lake laptop.

- Head: `6b68b98c5c39953dcfdce57ff2b95ba2ddfb1caf`
- Base includes latest fetched `origin/main` at `91c580a17`.
- Keeps Shaw/elizaOS llama.cpp as the native source of truth.
- Preserves the fused DFlash/QJL/TBQ/PolarQuant/Vulkan kernel stack and in-fork OmniVoice path.
- Makes the wrapper-side native artifact reproducible for `elizaOS/eliza` local-inference work.

## Validation

Built from the wrapper repo against this exact native SHA:

```bash
node packages/app-core/scripts/build-llama-cpp-dflash.mjs --target linux-x64-vulkan-fused --jobs 2
```

Result:

- build completed with `built=1`, `failed=0`
- installed artifact target: `linux-x64-vulkan-fused`
- `forkCommit`: `6b68b98c5c39953dcfdce57ff2b95ba2ddfb1caf`
- `publishable: true`
- `eliza1DefaultEligible: true`
- `missingRequiredKernels: []`
- kernels present: `dflash`, `turbo3`, `turbo4`, `turbo3_tcq`, `qjl_full`, `polarquant`, `lookahead`, `ngramDraft`
- binaries present: `llama-cli`, `llama-mtmd-cli`, `llama-server`, `llama-speculative-simple`, `omnivoice-codec`, `omnivoice-tts`
- OmniVoice verification: true
- ABI symbols include TTS, ASR, streaming TTS/ASR, VAD, verifier callback, and reference encoding exports
- `llama-server --help` exposes `--spec-type ... dflash`
- `ldd` resolves `libggml-vulkan`, `libggml-cpu`, `libllama`, and `libllama-common` from the installed fused bundle

Hardware graph-dispatch smoke on Intel Lunar Lake / Mesa ANV:

```bash
ELIZA_DFLASH_TARGET=linux-x64-vulkan-fused \
ELIZA_STATE_DIR=/home/nubs/.eliza \
ELIZA_DFLASH_TARGET_OUT_DIR=/home/nubs/.eliza/local-inference/bin/dflash/linux-x64-vulkan-fused \
ELIZA_DFLASH_VULKAN_BIN_DIR=/home/nubs/.eliza/local-inference/bin/dflash/linux-x64-vulkan-fused \
make -C plugins/plugin-local-inference/native/verify vulkan-dispatch-smoke
```

Result: pass, 7 graph routes.

- `GGML_OP_ATTN_SCORE_QJL`: 32 outputs, max diff `2.682e-07`
- `GGML_OP_ATTN_SCORE_TBQ/turbo3`: 32 outputs, max diff `9.537e-07`
- `GGML_OP_ATTN_SCORE_TBQ/turbo4`: 32 outputs, max diff `4.768e-07`
- `GGML_OP_ATTN_SCORE_TBQ/turbo3_tcq`: 32 outputs, max diff `7.153e-07`
- `GGML_OP_ATTN_SCORE_POLAR/use_qjl=0`: 32 outputs, max diff `1.907e-06`
- `GGML_OP_ATTN_SCORE_POLAR/use_qjl=1`: 32 outputs, max diff `1.907e-06`
- `GGML_OP_FUSED_ATTN_QJL_TBQ`: 512 outputs, max diff `4.470e-08`

## Notes

This remains draft while the wrapper-side desktop GUI voice/chat path continues. The native artifact itself is now locally proven on the target hardware.
