### PR TITLE
ci: fix 3rd-party Werror, android omnivoice-dac-parity link, vulkan test-gguf

### DIFF
--- a/tests/test-gguf.cpp
+++ b/tests/test-gguf.cpp
@@ -347,7 +347,13 @@ static FILE * get_handcrafted_file(const unsigned int seed, const enum handcraft
             name += "_" + std::to_string(i);
         }
         if (hft == HANDCRAFTED_TENSORS_BAD_NAME_SIZE) {
-            name += "_with_a_very_long_name_which_is_longer_than_what_is_allowed_for_ggml_tensors";
+            // Pad past GGML_MAX_NAME (default 64, can be raised at build time
+            // — omnivoice bumps it to 128). Keep growing until we're strictly
+            // over the limit so the "bad name size" branch actually exercises
+            // the oversize-name failure path under any GGML_MAX_NAME.
+            while (name.length() < (size_t) GGML_MAX_NAME) {
+                name += "_with_a_very_long_name_which_is_longer_than_what_is_allowed_for_ggml_tensors";
+            }
             GGML_ASSERT(name.length() >= GGML_MAX_NAME);
         }
         {

--- a/tools/kokoro/include/kokoro-layers.h
+++ b/tools/kokoro/include/kokoro-layers.h
@@ -147,6 +147,9 @@ inline void convtranspose1d_forward(
         const float * W, const float * b, int Cout, int K,
         int stride, int pad, int output_pad,
         float * y, int T_out) {
+    // output_pad affects T_out (computed by caller) but does not change
+    // the per-element formula here.
+    (void)output_pad;
     // Zero output, then add contributions.
     std::memset(y, 0, sizeof(float) * (size_t)Cout * (size_t)T_out);
     if (b) {
@@ -179,6 +182,9 @@ inline void convtranspose1d_depthwise_forward(
         const float * W, const float * b, int K,
         int stride, int pad, int output_pad,
         float * y, int T_out) {
+    // output_pad affects T_out (computed by caller) but does not change
+    // the per-element formula here.
+    (void)output_pad;
     std::memset(y, 0, sizeof(float) * (size_t)C * (size_t)T_out);
     for (int c = 0; c < C; ++c) {
         const float * xi = x + (size_t)c * T;

--- a/tools/omnivoice/CMakeLists.txt
+++ b/tools/omnivoice/CMakeLists.txt
@@ -244,25 +244,24 @@ target_link_libraries(omnivoice-test-abi-c PRIVATE omnivoice_lib)
 # dac_conv_t1d's ggml_conv_transpose_1d migration (elizaOS/eliza#7660).
 # The default run uses deterministic synthetic DAC block shapes; pass
 # `--gguf <omnivoice-tokenizer.gguf>` to exercise real conv_t1 weights.
-add_executable(omnivoice-dac-parity tests/dac-parity.cpp)
-target_compile_features(omnivoice-dac-parity PRIVATE cxx_std_17)
-target_include_directories(omnivoice-dac-parity PRIVATE
-    ${CMAKE_SOURCE_DIR}/ggml/include
-    ${CMAKE_SOURCE_DIR}/ggml/src)
-# Link ggml-cpu / ggml-base only when those CMake targets actually exist.
-# On some cross-compile configurations (Android NDK in particular) the
-# ggml-cpu target may not be defined, and naming it unconditionally in
-# target_link_libraries makes CMake fall back to a literal `-lggml-cpu`
-# link flag against a phantom library. Guard the link the same way
-# tools/kokoro/CMakeLists.txt does for kokoro_lib.
-target_link_libraries(omnivoice-dac-parity PRIVATE ggml)
-if(TARGET ggml-base)
-    target_link_libraries(omnivoice-dac-parity PRIVATE ggml-base)
-endif()
+#
+# The parity harness calls ggml_backend_cpu_init / ggml_backend_cpu_set_n_threads
+# directly, so it can only be built when the ggml-cpu CMake target is present.
+# On some cross-compile configurations (Android NDK in particular) the ggml-cpu
+# target is not defined, and the executable would fail to link. Gate the whole
+# target on ggml-cpu availability so those builds skip it cleanly.
 if(TARGET ggml-cpu)
-    target_link_libraries(omnivoice-dac-parity PRIVATE ggml-cpu)
-endif()
+    add_executable(omnivoice-dac-parity tests/dac-parity.cpp)
+    target_compile_features(omnivoice-dac-parity PRIVATE cxx_std_17)
+    target_include_directories(omnivoice-dac-parity PRIVATE
+        ${CMAKE_SOURCE_DIR}/ggml/include
+        ${CMAKE_SOURCE_DIR}/ggml/src)
+    target_link_libraries(omnivoice-dac-parity PRIVATE ggml ggml-cpu)
+    if(TARGET ggml-base)
+        target_link_libraries(omnivoice-dac-parity PRIVATE ggml-base)
+    endif()
 
-if(BUILD_TESTING)
-    add_test(NAME omnivoice-dac-parity COMMAND omnivoice-dac-parity --no-real)
+    if(BUILD_TESTING)
+        add_test(NAME omnivoice-dac-parity COMMAND omnivoice-dac-parity --no-real)
+    endif()
 endif()


### PR DESCRIPTION
## Summary
Three CI fixes for failures on main HEAD (22582b21a):

- **`CI (3rd-party)`** — `tools/kokoro/include/kokoro-layers.h` had two `output_pad` parameters that go unused in the per-element body (the caller uses them to size `T_out`). `-Werror=unused-parameter` failed the build on ubuntu-24-llguidance. Cast to `(void)` and document why.
- **`CI (android)`** — `omnivoice-dac-parity` was being added unconditionally and called `ggml_backend_cpu_init` / `ggml_backend_cpu_set_n_threads`, but android NDK cross-compile doesn't define a `ggml-cpu` CMake target, producing `undefined symbol` link errors. Gate the whole `add_executable` + `add_test` on `if(TARGET ggml-cpu)` so backends without CPU silently skip it. Matches the pattern `tools/kokoro/CMakeLists.txt` already uses for `kokoro_lib`.
- **`CI (vulkan)`** — `tests/test-gguf.cpp` had a hard-coded ~88-char long-name string for the `HANDCRAFTED_TENSORS_BAD_NAME_SIZE` case. omnivoice's CMakeLists bumps `GGML_MAX_NAME` to 128 PUBLIC on the ggml/llama targets, so the test name was no longer longer than the limit and the in-test sanity `GGML_ASSERT(name.length() >= GGML_MAX_NAME)` fired. Pad the suffix in a loop so the oversize-name path is always exercised under any `GGML_MAX_NAME`.

## Test plan
- [ ] CI (3rd-party) green (ubuntu-24-llguidance build)
- [ ] CI (android) green (gradlew build, arm64-v8a)
- [ ] CI (vulkan) green (test-gguf passes on ubuntu-24-vulkan-llvmpipe)
- [ ] Other workflows (CI, Server, sycl, cann, apple, sanitize…) remain unaffected