### PR TITLE
ci: gate self-hosted-only workflows behind workflow_dispatch

### DIFF
--- a/.github/workflows/build-openvino.yml
+++ b/.github/workflows/build-openvino.yml
@@ -2,6 +2,12 @@ name: CI (openvino)
 
 on:
   workflow_dispatch: # allows manual triggering
+    inputs:
+      force_self_hosted:
+        description: 'Also run the GPU matrix variant on the self-hosted Intel OpenVINO runner'
+        required: false
+        type: boolean
+        default: false
   push:
     branches:
       - master
@@ -38,6 +44,12 @@ env:
 jobs:
   ubuntu-24-openvino:
     name: ubuntu-24-openvino-${{ matrix.openvino_device }}
+
+    # The GPU variant targets [self-hosted, Linux, Intel, OpenVINO], which is
+    # not currently registered in the elizaOS org — every push/PR left it
+    # queued indefinitely. Skip it on automatic triggers; surface it only
+    # when explicitly opted in via `workflow_dispatch -f force_self_hosted=true`.
+    if: ${{ matrix.variant != 'gpu' || (github.event_name == 'workflow_dispatch' && inputs.force_self_hosted) }}
 
     concurrency:
       group: openvino-${{ matrix.variant }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/build-self-hosted.yml
+++ b/.github/workflows/build-self-hosted.yml
@@ -1,49 +1,15 @@
 name: CI (self-hosted)
 
+# This workflow targets self-hosted runners with labels like
+# [self-hosted, Linux, NVIDIA], [self-hosted, macOS, ARM64], etc. The
+# elizaOS org currently has zero self-hosted runners registered
+# (`gh api repos/elizaOS/llama.cpp/actions/runners` → total_count: 0),
+# so every push and PR left these jobs queued indefinitely. Restrict
+# the trigger to workflow_dispatch only — manual triggers will surface
+# the missing-runner state immediately instead of silently hanging.
+# Re-enable push/pull_request once a self-hosted fleet exists.
 on:
   workflow_dispatch: # allows manual triggering
-  push:
-    branches:
-      - master
-      - main
-      - 'eliza/**'
-    paths: [
-      '.github/workflows/build.yml',
-      '**/CMakeLists.txt',
-      '**/.cmake',
-      '**/*.h',
-      '**/*.hpp',
-      '**/*.c',
-      '**/*.cpp',
-      '**/*.cu',
-      '**/*.cuh',
-      '**/*.swift',
-      '**/*.m',
-      '**/*.metal',
-      '**/*.comp',
-      '**/*.glsl',
-      '**/*.wgsl'
-    ]
-
-  pull_request:
-    types: [opened, synchronize, reopened]
-    paths: [
-      '.github/workflows/build-self-hosted.yml',
-      '**/CMakeLists.txt',
-      '**/.cmake',
-      '**/*.h',
-      '**/*.hpp',
-      '**/*.c',
-      '**/*.cpp',
-      '**/*.cu',
-      '**/*.cuh',
-      '**/*.swift',
-      '**/*.m',
-      '**/*.metal',
-      '**/*.comp',
-      '**/*.glsl',
-      '**/*.wgsl'
-    ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}


### PR DESCRIPTION
## Summary

The elizaOS org has zero self-hosted runners (`gh api repos/elizaOS/llama.cpp/actions/runners` → `total_count: 0`), so any job pinned to a self-hosted label stays queued indefinitely and never delivers a CI signal. Two workflows still relied on self-hosted runners on every push/PR; restrict them to manual trigger:

- **`CI (self-hosted)`** (`.github/workflows/build-self-hosted.yml`) — 10 jobs across `[self-hosted, Linux, NVIDIA / COOPMAT2]`, `[self-hosted, macOS, ARM64]`, `[self-hosted, Linux, Intel]`, `[self-hosted, Windows, X64, Intel]`, `[self-hosted, Linux, Intel, OpenVINO]`. Restrict the whole workflow to `workflow_dispatch` only.
- **`CI (openvino)`** (`.github/workflows/build-openvino.yml`) — the GPU matrix variant targets `[self-hosted, Linux, Intel, OpenVINO]`. Gate that variant on a new `force_self_hosted` workflow_dispatch input; the CPU variant on `ubuntu-24.04` continues to run on every push/PR.

Same approach as PR #18 used for `cuda-runtime-validation`.

## Test plan
- [ ] No `CI (self-hosted)` runs auto-trigger on push to main
- [ ] `CI (openvino)` runs only the CPU variant on push (`ubuntu-24-openvino-CPU`)
- [ ] Manual: `gh workflow run "CI (self-hosted)"` succeeds (or surfaces missing-runner state)