### PR TITLE
fix(omnivoice): drop -Wshadow to unblock LLAMA_FATAL_WARNINGS (CI 3rd-party)

### DIFF
--- a/tools/omnivoice/CMakeLists.txt
+++ b/tools/omnivoice/CMakeLists.txt
@@ -105,8 +105,12 @@ if(MSVC)
     target_compile_options(omnivoice_lib PRIVATE
         /W4 /wd4100 /wd4505)
 else()
+    # -Wshadow intentionally omitted: omnivoice sources include llama's
+    # private headers + the public ggml-backend.h, neither of which are
+    # shadow-clean upstream. Under -DLLAMA_FATAL_WARNINGS=ON those
+    # warnings escalate to -Werror and break the 3rd-party CI lane.
     target_compile_options(omnivoice_lib PRIVATE
-        -Wall -Wextra -Wshadow -Wconversion
+        -Wall -Wextra -Wconversion
         -Wno-unused-parameter -Wno-unused-function -Wno-sign-conversion)
 endif()
 


### PR DESCRIPTION
## Summary

PR #18 unblocked the multi-line-comment failure in `CI (3rd-party)`. The next layer of failure exposed under `-DLLAMA_FATAL_WARNINGS=ON`:

```
ggml-backend.h:427: 'ggml_backend_graph_copy' hides constructor for 'struct ggml_backend_graph_copy'
llama-arch.h:623:   declaration of 'arch' shadows a member of 'LLM_TN'
llama-adapter.h:60: declaration of 'a'/'b' shadows a member of 'llama_adapter_lora_weight'
```

All three are in **upstream** llama.cpp headers, but `omnivoice_lib` enabled `-Wshadow` on its own translation units which pulled in those headers, and `-DLLAMA_FATAL_WARNINGS=ON` escalated them to `-Werror`.

Drop `-Wshadow` from `omnivoice_lib`. Keep `-Wall -Wextra -Wconversion` (and the `-Wno-*` suppressions) so omnivoice's own code is still warning-checked. The omnivoice shared library and `omnivoice-test-abi-c` already don't enable `-Wshadow`.

## Test plan
- [ ] CI (3rd-party) ubuntu-24-llguidance green
- [ ] Other CI lanes unaffected (omnivoice still compiles with -Wall/-Wextra)