### PR TITLE
Merge wave-14 CI fixes from eliza/token-trie-sampler

### DIFF
--- a/common/debug.cpp
+++ b/common/debug.cpp
@@ -162,7 +162,7 @@ bool common_debug_cb_eval(struct ggml_tensor * t, bool ask, void * user_data) {
         }
     }
 
-    char src1_str[128] = { 0 };
+    char src1_str[256] = { 0 };
     if (src1) {
         snprintf(src1_str, sizeof(src1_str), "%s{%s}", src1->name, common_ggml_ne_string(src1).c_str());
     }

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -58,6 +58,11 @@ DispatchLoaderDynamic & ggml_vk_default_dispatcher();
 #if defined(_MSC_VER)
 # define NOMINMAX 1
 # include <windows.h>
+// windows.h (winnt.h) defines MemoryBarrier as a macro that expands to an
+// intrinsic call (e.g. __faststorefence()). That collides with vk::MemoryBarrier
+// and causes MSVC C2146 syntax errors. Undefine it; nothing in this TU needs
+// the Win32 MemoryBarrier intrinsic.
+# undef MemoryBarrier
 # define YIELD() YieldProcessor()
 #elif defined(__clang__) || defined(__GNUC__)
 # if defined(__x86_64__) ||defined(__i386__)

--- a/src/llama-adapter.h
+++ b/src/llama-adapter.h
@@ -83,7 +83,7 @@ struct llama_adapter_lora {
     llama_adapter_lora_weight * get_weight(ggml_tensor * w);
 
     uint32_t get_n_nodes() const {
-        return ab_map.size() * 6u; // a, b, scale, add, 2 x mul_mat
+        return static_cast<uint32_t>(ab_map.size()) * 6u; // a, b, scale, add, 2 x mul_mat
     }
 };
 


### PR DESCRIPTION
Brings the three wave-14 CI fixes onto main.

## Commits
- `8c1aa8079` fix(adapter): cast `ab_map.size()` to `uint32_t` in `get_n_nodes()` — unblocks `-Werror=conversion` on gcc 13+
- `c95a92542` fix(debug): widen `src1_str` buffer to 256 — unblocks `-Werror=format-truncation`
- `b12f29b66` fix(vulkan): `#undef MemoryBarrier` after `<windows.h>` — unblocks MSVC C2146 syntax error on Windows Vulkan build

## Local verification
- `cmake --build build-codex-merge --target llama-cli omnivoice-tts kokoro-tts` — PASS on Mac
- `llama-cli` smoke on eliza-1-0_8b-128k.gguf: `Prompt: 556.8 t/s | Generation: 209.9 t/s` — PASS
- Issue 3 (MSVC) cannot be verified locally on macOS; the fix targets the exact `windows.h` `MemoryBarrier` macro vs `vk::MemoryBarrier` collision at the reported line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)