### PR TITLE
fix(omnivoice-codec): make main_impl static to satisfy -Wmissing-declarations

### DIFF
--- a/tools/omnivoice/tools/omnivoice-codec.cpp
+++ b/tools/omnivoice/tools/omnivoice-codec.cpp
@@ -155,7 +155,7 @@ static int infer_mode(const char * path) {
     return 0;
 }
 
-int main_impl(int argc, char ** argv) {
+static int main_impl(int argc, char ** argv) {
     if (argc <= 1) {
         print_usage(argv[0]);
         return 0;


### PR DESCRIPTION
Follow-up to PR #23.

`tools/omnivoice/tools/omnivoice-codec.cpp:158` defines `int main_impl(int, char**)` at file scope without prior declaration. Under `-DLLAMA_FATAL_WARNINGS=ON` (CI 3rd-party / ubuntu-24-llguidance) this fails:

```
tools/omnivoice/tools/omnivoice-codec.cpp:158:5: error: no previous declaration for 'int main_impl(int, char**)' [-Werror=missing-declarations]
```

The sibling tool `omnivoice-tts.cpp` already marks its `main_impl` static (line 411). Match it.