### PR TITLE
build(omnivoice): port the fused elizainference DLL build to Windows/MSVC

### DIFF
--- a/tools/omnivoice/CMakeLists.txt
+++ b/tools/omnivoice/CMakeLists.txt
@@ -128,6 +128,14 @@ target_include_directories(eliza_voice_classifiers PUBLIC
     ${OMNIVOICE_VOICE_CLASSIFIER_INCLUDE_DIRS})
 if(MSVC)
     target_compile_options(eliza_voice_classifiers PRIVATE /W3 /wd4100)
+    # The vendored voice-classifier C sources include <sys/mman.h> and
+    # <unistd.h> (POSIX) to mmap their GGUF files read-only and use
+    # open/close/read. MSVC ships neither header; this compat dir provides
+    # thin shims (mmap over Win32 file mapping; unistd over <io.h>) so the
+    # static lib — folded into the fused elizainference DLL — builds on
+    # Windows. Prepended via BEFORE so <sys/mman.h>/<unistd.h> resolve here.
+    target_include_directories(eliza_voice_classifiers BEFORE PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/compat/msvc)
 else()
     target_compile_options(eliza_voice_classifiers PRIVATE
         -O3 -Wall -Wextra -Wno-unused-parameter)
@@ -273,7 +281,14 @@ if(TARGET mtmd)
     endif()
     set_target_properties(elizainference PROPERTIES
         OUTPUT_NAME              elizainference
-        POSITION_INDEPENDENT_CODE ON)
+        POSITION_INDEPENDENT_CODE ON
+        # On Windows/MSVC symbols are NOT exported by default (unlike the Unix
+        # `default` visibility this target relies on), so the extern "C"
+        # eliza_inference_* / ov_* FFI surface the JS loader dlsym()s would be
+        # absent from the DLL (bun:ffi: "Symbol eliza_inference_abi_version not
+        # found"). Auto-generate an export table for every symbol so Windows
+        # matches the Unix default-export behavior the runtime assumes.
+        WINDOWS_EXPORT_ALL_SYMBOLS ON)
     # Apple re-exports llama symbols so the fused .dylib carries everything
     # JS will dlopen() without a second handle. Mirrors the legacy fork-root
     # graft block.

--- a/tools/omnivoice/compat/msvc/sys/mman.h
+++ b/tools/omnivoice/compat/msvc/sys/mman.h
@@ -1,0 +1,52 @@
+/* Minimal read-only mmap shim for MSVC / Windows.
+ *
+ * The vendored voice-classifier sources (wakeword / voice_classifier / vad)
+ * map their GGUF files read-only — always
+ *   mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0)  /  munmap(addr, size)
+ * — so this shim implements exactly that surface over the Win32 file-mapping
+ * API. It is only on the include path for MSVC builds (see the eliza_voice_
+ * classifiers target in tools/omnivoice/CMakeLists.txt); POSIX hosts use the
+ * real <sys/mman.h>.
+ */
+#ifndef ELIZA_COMPAT_MSVC_SYS_MMAN_H
+#define ELIZA_COMPAT_MSVC_SYS_MMAN_H
+
+#include <io.h> /* _get_osfhandle */
+#include <stddef.h>
+#include <windows.h>
+
+#define PROT_NONE 0x0
+#define PROT_READ 0x1
+#define PROT_WRITE 0x2
+
+#define MAP_SHARED 0x1
+#define MAP_PRIVATE 0x2
+
+#define MAP_FAILED ((void *)-1)
+
+static __inline void *mmap(void *addr, size_t length, int prot, int flags,
+                           int fd, long offset) {
+  (void)addr;
+  (void)prot;
+  (void)flags;
+  HANDLE file = (HANDLE)_get_osfhandle(fd);
+  if (file == INVALID_HANDLE_VALUE) {
+    return MAP_FAILED;
+  }
+  HANDLE mapping = CreateFileMappingW(file, NULL, PAGE_READONLY, 0, 0, NULL);
+  if (mapping == NULL) {
+    return MAP_FAILED;
+  }
+  void *view = MapViewOfFile(mapping, FILE_MAP_READ, 0, (DWORD)offset, length);
+  /* The mapped view holds a reference to the mapping object, so the handle can
+   * be released immediately; munmap() then only needs the base address. */
+  CloseHandle(mapping);
+  return view ? view : MAP_FAILED;
+}
+
+static __inline int munmap(void *addr, size_t length) {
+  (void)length;
+  return UnmapViewOfFile(addr) ? 0 : -1;
+}
+
+#endif /* ELIZA_COMPAT_MSVC_SYS_MMAN_H */

--- a/tools/omnivoice/compat/msvc/unistd.h
+++ b/tools/omnivoice/compat/msvc/unistd.h
@@ -1,0 +1,21 @@
+/* Minimal <unistd.h> shim for MSVC / Windows.
+ *
+ * The vendored voice-classifier sources use open()/close()/read() and ssize_t
+ * from <unistd.h>, which MSVC does not ship. MSVC exposes the POSIX I/O names
+ * (open/close/read/lseek) from <io.h> under _CRT_DECLARE_NONSTDC_NAMES (the
+ * default), and ssize_t maps to the Win32 SSIZE_T. Only on the MSVC include
+ * path (see tools/omnivoice/CMakeLists.txt); POSIX hosts use the real header.
+ */
+#ifndef ELIZA_COMPAT_MSVC_UNISTD_H
+#define ELIZA_COMPAT_MSVC_UNISTD_H
+
+#include <basetsd.h> /* SSIZE_T */
+#include <io.h>      /* open, close, read, lseek (POSIX names) */
+#include <process.h>
+
+#ifndef _SSIZE_T_DEFINED
+#define _SSIZE_T_DEFINED
+typedef SSIZE_T ssize_t;
+#endif
+
+#endif /* ELIZA_COMPAT_MSVC_UNISTD_H */

--- a/tools/omnivoice/src/eliza-inference-ffi.cpp
+++ b/tools/omnivoice/src/eliza-inference-ffi.cpp
@@ -80,6 +80,19 @@ extern "C" {
 #include <unordered_map>
 #include <vector>
 
+#ifdef _WIN32
+/* MSVC has no POSIX setenv/unsetenv. The only use below pins/restores
+ * GGML_BACKEND around ov_init (overwrite is always 1); map both onto
+ * _putenv_s (from <cstdlib>), which removes the variable when value is "". */
+static inline int setenv(const char *name, const char *value, int overwrite) {
+  if (!overwrite && std::getenv(name) != nullptr) {
+    return 0;
+  }
+  return _putenv_s(name, value);
+}
+static inline int unsetenv(const char *name) { return _putenv_s(name, ""); }
+#endif
+
 /* OmniVoice voice-preset payload parsed from
  * <bundle_dir>/cache/voice-preset-<id>.bin (ELZ2 v2 binary format). v1
  * presets (Kokoro-style: embedding + phrase-cache seed only) parse with


### PR DESCRIPTION
Ports the fused `elizainference` (libelizainference) build to Windows/MSVC.
All changes are Windows-only (`if(MSVC)` / `#ifdef _WIN32`), so non-Windows
builds (android/apple/vulkan/…) are unaffected.

- `WINDOWS_EXPORT_ALL_SYMBOLS ON` on the `elizainference` target — MSVC does not
  export symbols by default, so the extern "C" `eliza_inference_*` / `ov_*` FFI
  surface the JS bun:ffi loader dlsym()s was absent from the DLL.
- `tools/omnivoice/compat/msvc/{sys/mman.h,unistd.h}` — the vendored voice-
  classifier C sources mmap their GGUF files read-only via POSIX headers MSVC
  lacks; thin shims (mmap over Win32 file mapping; unistd over <io.h>), wired
  into `eliza_voice_classifiers` only on MSVC.
- `eliza-inference-ffi.cpp` — POSIX `setenv`/`unsetenv` mapped onto `_putenv_s`
  under `_WIN32`.

Verified on windows-x64 CPU: `elizainference.dll` builds, exports its ABI-v12
FFI surface, loads via bun:ffi (`supported()==true`), and generates text from
the eliza-1-0_8b bundle.