### PR TITLE
fix(omnivoice): silence -Werror=double-promotion in voice classifiers

### DIFF
--- a/tools/omnivoice/src/voice-classifiers/voice_classifier/voice_diarizer.c
+++ b/tools/omnivoice/src/voice-classifiers/voice_classifier/voice_diarizer.c
@@ -114,11 +114,11 @@ static void inst_norm_1d_inplace(float *buf, int C, int L,
     for (int c = 0; c < C; ++c) {
         float *row = buf + (size_t)c * L;
         double sum = 0.0, sq = 0.0;
-        for (int i = 0; i < L; ++i) sum += row[i];
+        for (int i = 0; i < L; ++i) sum += (double)row[i];
         const float mean = (float)(sum / L);
         for (int i = 0; i < L; ++i) {
             const float d = row[i] - mean;
-            sq += (double)d * d;
+            sq += (double)d * (double)d;
         }
         const float var = (float)(sq / L);
         const float invstd = 1.0f / sqrtf(var + eps);

--- a/tools/omnivoice/src/voice-classifiers/voice_classifier/voice_speaker.c
+++ b/tools/omnivoice/src/voice-classifiers/voice_classifier/voice_speaker.c
@@ -335,7 +335,7 @@ static int spk_compute_fbank(const struct voice_speaker_session *s,
 
         /* DC offset removal. */
         double dc = 0.0;
-        for (int i = 0; i < SPK_WINDOW_LEN; ++i) dc += frame[i];
+        for (int i = 0; i < SPK_WINDOW_LEN; ++i) dc += (double)frame[i];
         dc /= (double)SPK_WINDOW_LEN;
         for (int i = 0; i < SPK_WINDOW_LEN; ++i) frame[i] -= (float)dc;
 
@@ -370,7 +370,7 @@ static int spk_compute_fbank(const struct voice_speaker_session *s,
     /* Per-utterance CMN. */
     for (int m = 0; m < SPK_N_MELS; ++m) {
         double mean = 0.0;
-        for (int t = 0; t < frames; ++t) mean += feats_out[t * SPK_N_MELS + m];
+        for (int t = 0; t < frames; ++t) mean += (double)feats_out[t * SPK_N_MELS + m];
         mean /= (double)frames;
         for (int t = 0; t < frames; ++t) feats_out[t * SPK_N_MELS + m] -= (float)mean;
     }
@@ -572,7 +572,7 @@ int voice_speaker_embed(voice_speaker_handle h,
         for (int oh = 0; oh < 10; ++oh) {
             const float *slot = cur + ((size_t)oc * 10 + oh) * T_pool;
             double mean = 0.0;
-            for (int t = 0; t < T_pool; ++t) mean += slot[t];
+            for (int t = 0; t < T_pool; ++t) mean += (double)slot[t];
             mean /= (double)T_pool;
             double var = 0.0;
             for (int t = 0; t < T_pool; ++t) {


### PR DESCRIPTION
The `ubuntu-24-llguidance` CI job builds the fused omnivoice tool with `-DLLAMA_FATAL_WARNINGS=ON`, turning `-Wdouble-promotion` into a hard error. Five intentional float→double accumulations in the scalar voice-classifier forwards promoted a float operand implicitly:

- `voice_speaker.c`: DC-offset removal (338), mel mean-centering (373), TDNN stats-pool mean (575)
- `voice_diarizer.c`: instance-norm mean (117) and variance (121)

Each is made explicit with a `(double)` cast — identical numerics, warning gone. The sibling conv/linear `+=` accumulators are float (no promotion) and are correctly left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)