### PR TITLE
fix(kokoro): build across the full CI matrix (shared-lib PIC / Apple bundle / Android DL)

### DIFF
--- a/tools/kokoro/CMakeLists.txt
+++ b/tools/kokoro/CMakeLists.txt
@@ -33,6 +33,16 @@ add_library(kokoro_lib STATIC
 target_include_directories(kokoro_lib PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
+# kokoro_lib is folded into the fused libelizainference SHARED library
+# (tools/omnivoice/CMakeLists.txt links it PRIVATE). When the parent build is
+# configured with BUILD_SHARED_LIBS=ON (e.g. the OpenVINO Linux CI job), the
+# static archive's objects must be position-independent or ld refuses to fold
+# them into a -shared object ("relocation R_X86_64_PC32 ... can not be used
+# when making a shared object; recompile with -fPIC"). PIC is not transitive
+# from the SHARED consumer, so set it on the static target itself — mirroring
+# eliza_voice_classifiers / omnivoice_lib in the sibling omnivoice subtree.
+set_target_properties(kokoro_lib PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
 # ggml + llama are already configured by the parent build; pulling them via
 # target_link_libraries gives us the include paths and the link line.
 target_link_libraries(kokoro_lib PUBLIC ggml)
@@ -48,6 +58,12 @@ target_compile_features(kokoro_lib PUBLIC cxx_std_17)
 # Standalone CLI harness — required by J2 verification (tools/voice-kokoro/).
 add_executable(kokoro-tts tools/kokoro-tts.cpp)
 target_link_libraries(kokoro-tts PRIVATE kokoro_lib)
+# kokoro-tts is a CLI harness, not a GUI app. On Apple platforms CMake defaults
+# executables to MACOSX_BUNDLE, and install(TARGETS ... RUNTIME) on a bundle
+# target fails configure with "install TARGETS given no BUNDLE DESTINATION for
+# MACOSX_BUNDLE executable" on every ios/tvos/visionos/macos build. Force the
+# bundle flag off so the plain RUNTIME install is valid on all platforms.
+set_target_properties(kokoro-tts PROPERTIES MACOSX_BUNDLE OFF)
 install(TARGETS kokoro-tts RUNTIME)
 
 # Server-mount handler: compiled into kokoro_lib only when the server target

--- a/tools/kokoro/src/kokoro.cpp
+++ b/tools/kokoro/src/kokoro.cpp
@@ -213,9 +213,16 @@ kokoro_model_ptr kokoro_load_model(
     h.sample_rate        = gguf_i32(model->gguf, "kokoro.audio.sample_rate",   h.sample_rate);
 
     // Bind backend (CPU only for now — GGML graph below is CPU-friendly).
-    model->backend = ggml_backend_cpu_init();
+    // Use the registry API rather than ggml_backend_cpu_init(): under
+    // -DGGML_BACKEND_DL (the Android build) the CPU backend is a dynamically
+    // loaded module and ggml_backend_cpu_init() is not linked, so a direct call
+    // is an undefined symbol at link time. ggml_backend_load_all() is idempotent
+    // and registers the CPU device in both the DL and statically-linked builds,
+    // matching how the sibling omnivoice tool initializes its CPU backend.
+    ggml_backend_load_all();
+    model->backend = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, nullptr);
     if (!model->backend) {
-        err_out = "ggml_backend_cpu_init failed";
+        err_out = "ggml_backend_init_by_type(CPU) failed";
         return {nullptr, kokoro_model_deleter{}};
     }
 


### PR DESCRIPTION
Three distinct, backend-agnostic CI failures in the kokoro subtree, all portable build fixes:

| Lane(s) | Error | Fix |
|---|---|---|
| openvino, sycl, vulkan, virtgpu | `kokoro.cpp.o ... recompile with -fPIC` linking the fused `libelizainference.so` | `set_target_properties(kokoro_lib PROPERTIES POSITION_INDEPENDENT_CODE ON)` (mirrors `eliza_voice_classifiers`) |
| apple (ios/tvos/visionos/macos) | `install TARGETS given no BUNDLE DESTINATION for MACOSX_BUNDLE executable "kokoro-tts"` | `set_target_properties(kokoro-tts PROPERTIES MACOSX_BUNDLE OFF)` |
| android | `undefined symbol: ggml_backend_cpu_init` under `-DGGML_BACKEND_DL` | switch to `ggml_backend_load_all()` + `ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, nullptr)` (the registry API omnivoice uses) |

Found via an audit of all 8 failing fork-CI jobs. Compile-validated on MSVC (`kokoro_lib` builds); the Linux/Apple paths are CMake config + a portable registry call needing no backend SDK to be correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)