### PR TITLE
fix(metal): guard nil compute pipelines

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -99,6 +99,11 @@ void ggml_metal_pipeline_free(ggml_metal_pipeline_t pipeline) {
 }
 
 int ggml_metal_pipeline_max_theads_per_threadgroup(struct ggml_metal_pipeline_with_params pipeline) {
+    if (!pipeline.pipeline || !pipeline.pipeline->obj) {
+        GGML_LOG_ERROR("%s: error: Metal compute pipeline is nil\n", __func__);
+        GGML_ABORT("nil Metal compute pipeline");
+    }
+
     return pipeline.pipeline->obj.maxTotalThreadsPerThreadgroup;
 }
 
@@ -509,6 +514,11 @@ void ggml_metal_encoder_debug_group_pop (ggml_metal_encoder_t encoder) {
 }
 
 void ggml_metal_encoder_set_pipeline(ggml_metal_encoder_t encoder, struct ggml_metal_pipeline_with_params pipeline) {
+    if (!pipeline.pipeline || !pipeline.pipeline->obj) {
+        GGML_LOG_ERROR("%s: error: Metal compute pipeline is nil\n", __func__);
+        GGML_ABORT("nil Metal compute pipeline");
+    }
+
     [encoder->obj setComputePipelineState:pipeline.pipeline->obj];
 }
 


### PR DESCRIPTION
## Summary
- guard Metal pipeline dereferences in `ggml_metal_pipeline_max_theads_per_threadgroup` and `ggml_metal_encoder_set_pipeline`
- emit an explicit `nil Metal compute pipeline` backend failure instead of dereferencing a NULL pipeline state

Refs elizaOS/eliza#11612.

## Evidence
- PASS: `git diff --check` in the llama.cpp submodule
- N/A here: iPhone 16 Pro Max / A18 Pro runtime verification. This host is Linux and cannot build/run the Metal backend or reproduce the device-only crash.

## Notes
This is the defensive stop-the-NULL-deref patch. The root-cause work for why the A18 Pro `mul_mat` pipeline is nil still needs real-device Metal diagnostics.
