### PR TITLE
fix(inference): keep Android LLM weights resident

### DIFF
--- a/tools/omnivoice/src/eliza-inference-ffi.cpp
+++ b/tools/omnivoice/src/eliza-inference-ffi.cpp
@@ -1223,7 +1223,13 @@ static int eliza_load_llm_model_locked(
         n_gpu_layers >= 0
             ? n_gpu_layers
             : (eliza_bool_env_or_default("ELIZA_LLM_USE_GPU", true) ? 99 : 0);
-    mparams.use_mmap = true;
+    /* Android's packaged asset is copied into app-private storage before
+     * load, but the platform may still reclaim or invalidate file-backed
+     * pages under sustained native-memory pressure. ASR already uses this
+     * conservative Android profile. Keep text weights resident too, while
+     * preserving mmap on desktop and allowing an explicit device override. */
+    mparams.use_mmap = eliza_bool_env_or_default(
+        "ELIZA_LLM_USE_MMAP", !eliza_running_on_android());
     ctx->llm_model =
         llama_model_load_from_file(ctx->llm_model_path.c_str(), mparams);
     if (!ctx->llm_model) {


### PR DESCRIPTION
## Summary

- default `llama_model_params.use_mmap` to false on Android while preserving mmap elsewhere
- retain an `ELIZA_LLM_USE_MMAP` override for device experiments
- align text-model residency with the existing conservative Android ASR profile

## Evidence

On the elizaOS Android arm64 emulator, all GPU/CPU and fusion-on/off combinations previously reached `ggml_compute_forward_mul` and crashed with SIGSEGV while reading a stale file-backed tensor page. With this change, the same 1,270,808,512-byte Eliza-1 model completed a real native turn and the app process remained healthy for three consecutive probes.

Parent integration: elizaOS/eliza#22828.